### PR TITLE
fix: update npm scripts and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ npm publish
 
 ## License
 <a href='https://github.com/mipengine/mag-design/blob/master/LICENSE'>
-    <img src='https://img.shields.io/github/license/mashape/apistatus.svg'  title='license' alt='license'>
+    <img src='https://img.shields.io/github/license/mipengine/mag-design.svg'  title='license' alt='license'>
 </a>
 
 Copyright (c) 2017-present, Baidu Inc.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm run build
 
 使用对应的`class`即可使用相关样式。对于依赖html结构的样式簇，无法单独使用，必须在样式簇结构下使用。
 ```html
-    <div class="button"></div>
+<div class="button"></div>
 ```
 
 - 组件引用

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ require('mip-mag-design');
 clone仓库
 ```bash
 # 克隆仓库
-git clone xxx
+git clone https://github.com/mipengine/mag-design.git
 # 进入仓库目录
 cd mag-design/
 # 安装依赖
@@ -73,7 +73,7 @@ npm run build
 
 ```bash
 # 克隆仓库
-git clone xxx
+git clone https://github.com/mipengine/mag-design.git
 # 进入仓库目录
 cd mag-design/
 # 安装依赖
@@ -83,7 +83,7 @@ npm i
 ### 创建组件
 工具自动生成`styl`、`index.html`、`READEME.md`文件
 ```bash
-    npm run creat xxx
+npm run creat xxx
 ```
 
 ### 样式开发
@@ -103,12 +103,12 @@ npm i
 
 - 组件demo引入方式：
 ```html
-    <link rel="stylesheet" type="text/css" href="../mag-design.min.css">
+<link rel="stylesheet" type="text/css" href="../mag-design.min.css">
 ```
 
 - example下demo引入方式：
 ```html
-    <link rel="stylesheet" type="text/css" href="../dist/mag-design.min.css">
+<link rel="stylesheet" type="text/css" href="../dist/mag-design.min.css">
 ```
 
 
@@ -117,8 +117,6 @@ npm i
 
 ```bash
 npm run build
-# 或者
-./node_modules/gulp/bin/gulp.js build
 ```
 
 ### 预览

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-rimraf": "^0.2.1",
     "gulp-sourcemaps": "^2.6.1",
+    "gulp-stylus": "^2.6.0",
     "minimist": "^1.2.0"
   },
   "scripts": {
@@ -37,8 +38,5 @@
   "dependencies": {
     "nib": "^1.1.2",
     "normalize.css": "^7.0.0"
-  },
-  "devDependencies": {
-    "gulp-stylus": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "minimist": "^1.2.0"
   },
   "scripts": {
-    "build": "./node_modules/gulp/bin/gulp.js build",
-    "test": "./node_modules/gulp/bin/gulp.js test",
-    "preview": "./node_modules/gulp/bin/gulp.js preview --cp",
-    "creat": "./node_modules/gulp/bin/gulp.js creat --cp"
+    "build": "gulp build",
+    "test": "gulp test",
+    "preview": "gulp preview --cp",
+    "creat": "gulp creat --cp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. 更新 `npm run scripts` 脚本路径，因为在 `package.json` 中配置的 `scripts` 可以直接使用命令。
1. 删除了文档中的 `./node_modules/gulp/bin/gulp.js build` ，个人认为命令应该统一化。
1. 修改了开源协议图标，现在的是使用 <https://github.com/mashape/apistatus> 仓库的协议引用。
1. 修改了部分文档。
1. 修改了 `package.json` 中2个 `devDependencies` 字段（现在的编译报错就是这个引起的）。